### PR TITLE
don't call GEoJSONPolyline when the method is null

### DIFF
--- a/geojson-polyline.js
+++ b/geojson-polyline.js
@@ -178,7 +178,9 @@ if (typeof addEventListener !== 'undefined') {
     var method = message.data[0]
     var geojson = message.data[1]
     var precision = message.data[2]
-    var converted = GeoJSONPolyline[method](geojson, precision)
+    if(method)
+      var converted = GeoJSONPolyline[method](geojson, precision)
+    else return false;
     postMessage(converted)
   })
 }


### PR DESCRIPTION
This closes #4

This resolves the erros prompted in Vue.js projects.

Uncaught TypeError: GeoJSONPolyline[method] is not a function